### PR TITLE
Saving data from pre-check even if non nil error is returned

### DIFF
--- a/coordinator.go
+++ b/coordinator.go
@@ -141,6 +141,12 @@ func (c *Coordinator) executeStep(i int, input interface{}) error {
 
 	preCheckResp := preCheckValue.Call(preCheckParams)
 
+	if output, ok := isReturnOutput(preCheckResp); ok {
+		if db, ok := c.ctx.Value(DataBagContextKey).(*DataBag); ok {
+			db.setPreCheckData(c.stepName(i), output)
+		}
+	}
+
 	err = isReturnError(preCheckResp)
 	if err != nil {
 		c.err = append(c.err, errors.Wrapf(err, "preCheck '%s'", c.stepName(i)))
@@ -152,12 +158,6 @@ func (c *Coordinator) executeStep(i int, input interface{}) error {
 		}
 
 		return nil
-	}
-
-	if output, ok := isReturnOutput(preCheckResp); ok {
-		if db, ok := c.ctx.Value(DataBagContextKey).(*DataBag); ok {
-			db.setPreCheckData(c.stepName(i), output)
-		}
 	}
 
 	jobValue := reflect.ValueOf(c.steps[i].Job)


### PR DESCRIPTION
Sometimes when doing a pre-check we may want to return some ID retrieved in this step. Consider example:
On first run we have added a record to DB and received its ID (first step job), but next job failed and we need to
retry for this record. Now first step pre-check will respond that the record exists so job will not be run. In such case
we will have no record ID for further steps.

This change covers this situation because we can easily return this ID from pre-check.